### PR TITLE
fix: abnormal percentage display.

### DIFF
--- a/src/components/UsageBar/index.tsx
+++ b/src/components/UsageBar/index.tsx
@@ -12,7 +12,7 @@ const PERCENT_WITH_STATUS = {
 
 function calcPercent(p: number) {
   let percent: number | string = 100 * p;
-  if (percent < 0.0001 && percent > 0) {
+  if (percent < 0.01 && percent > 0) {
     percent = '0.01%';
   } else if (percent < 1) {
     percent = `${percent.toFixed(3)}%`;


### PR DESCRIPTION
http://issue.xsky.com/browse/WIZARD-5192?filter=-1

问题原因：calcPercent 中先将 percent * 100 了，所以小于 0.01% 的判断应该为 percent < 0.01；
所以之前 0.0001～0.000001 之间的没法正常显示为 0.01%