### PR TITLE
fix/tabs: Tabs-body should changes width route

### DIFF
--- a/docs/content/components/tab.mdx
+++ b/docs/content/components/tab.mdx
@@ -20,21 +20,6 @@ date: 2019-06-12
 </div>
 ```
 
-### 动画过度效果
-```
-<div className="bg-gray">
-  <Tabs
-    useAnimation
-    tabs={[
-      { title: '标题1', key: 'key-1', children: <div>第1个tab</div> },
-      { title: '标题2', key: 'key-2', children: <div>第2个tab</div> },
-      { title: '标题3', key: 'key-3', children: <div>第3个tab</div> },
-      { title: '标题4', key: 'key-4', children: <div>第4个tab</div> }
-    ]}
-  />
-</div>
-```
-
 ### 改变大小
 ```
 <div className="bg-gray">
@@ -66,7 +51,7 @@ date: 2019-06-12
 ```
 
 ### 监听选项卡切换
-limitNum 属性默认展示100个tab
+limitNum 属性默认展示5个tab
 ```jsx
 () => {
   const TABS = [

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -15,15 +15,31 @@ const Tabs: React.FC<TabsProps> = props => {
     direction,
     limitNum = 5,
     onSelect,
+    activeKey,
     ...restProps
   } = props;
 
   const [keyTitle, setKeyTitleValue] = React.useState<string>(MORE_TITLE);
-  const [TabsPan, TabsPanValue] = React.useState<any>(tabs[0]);
+  const TabsPan = activeKey ? tabs.filter(item => { return item[eventKeyName] === activeKey })[0] : tabs[0];
   const tabsFrontList = tabs.slice(0, limitNum);
   const tabsLastList = tabs.slice(limitNum, tabs.length);
   const showMore = tabsLastList.length !== 0;
 
+  React.useEffect(() => {
+    if (showMore) {
+      let k = 0;
+      let isFind = false;
+      while (k < tabs.length && !isFind) {
+        let cTab = tabs[k];
+        if (cTab[eventKeyName] === activeKey && k >= limitNum) {
+          isFind = true;
+          setKeyTitleValue(cTab.title);
+          return;
+        }
+        k++;
+      }
+    }
+  }, [])
   const handleSelect = React.useCallback(
     (activeKey: any) => {
       if (onSelect) {
@@ -33,7 +49,7 @@ const Tabs: React.FC<TabsProps> = props => {
         let k = 0;
         let isFind = false;
         while (k < tabs.length && !isFind) {
-          const cTab = tabs[k];
+          let cTab = tabs[k];
           if (cTab[eventKeyName] === activeKey && k >= limitNum) {
             isFind = true;
             setKeyTitleValue(cTab.title);
@@ -44,9 +60,6 @@ const Tabs: React.FC<TabsProps> = props => {
           setKeyTitleValue(MORE_TITLE);
         }
       }
-      const TabActiveKey = activeKey
-      const ActiveTabs = tabs.filter(item => { return item[eventKeyName] == TabActiveKey })[0]
-      TabsPanValue(ActiveTabs);
     },
     [tabs],
   );
@@ -56,7 +69,7 @@ const Tabs: React.FC<TabsProps> = props => {
       <Tab.Container
         id="tabs-with-dropdown"
         onSelect={handleSelect}
-        defaultActiveKey={tabs[0]['key']}
+        defaultActiveKey={activeKey ? TabsPan['key'] : tabs[0]['key']}
         {...restProps}
       >
         <div className="clearfix ">


### PR DESCRIPTION
问题：tabs组件内容的选择没有根据页面路由决定 （页面刷新，路由是“生命周期”，而tabs渲染后内容指定是第一个）
修改：通过传入的activekey，渲染tabs选中的内容。