### PR TITLE
Limit tab max-width

### DIFF
--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -56,6 +56,7 @@ const Tabs: React.FC<TabsProps> = props => {
           <Nav bsStyle="tabs">
             {tabsFrontList.map((tab, idx) => (
               <NavItem
+                title={tab['title']}
                 key={eventKeyName ? tab[eventKeyName] : idx}
                 eventKey={eventKeyName ? tab[eventKeyName] : idx}
               >

--- a/src/components/Tabs/style.scss
+++ b/src/components/Tabs/style.scss
@@ -41,6 +41,23 @@
     padding-right: 20px;
     min-width: 67px;
     text-align: center;
+    display: inline-block;
+    max-width: 120px;
+    white-space:nowrap;
+    overflow:hidden;
+    text-overflow:ellipsis;
+
+    &.dropdown-toggle {
+      position: relative;
+      padding-right: 25px;
+      max-width: 150px;
+
+      & .caret {
+        position: absolute;
+        top:16px;
+        right: 15px;
+      }
+    }
 
     &:hover {
       background-color: $purple-lighter-3;


### PR DESCRIPTION
Signed-off-by: zghzzj <2627191377@qq.com>

##优化：限制tab标题的宽度
以中文字体6字为标准 max-width=120px
![image](https://user-images.githubusercontent.com/34362276/77525353-db96e980-6ec3-11ea-9924-b8f62db47c05.png)
![image](https://user-images.githubusercontent.com/34362276/77525384-ea7d9c00-6ec3-11ea-8b6d-bb25e3ebfdd2.png)


##优化结果：
可以按照设计方案使用，s鼠标移动上去，会显示全部标题
![image](https://user-images.githubusercontent.com/34362276/77525073-69260980-6ec3-11ea-94c5-04957fda1664.png)


##测试结果： 
给 NavItem 添加 title属性，导致渲染rander tabs 的断言测试失败。
![image](https://user-images.githubusercontent.com/34362276/77525203-9a9ed500-6ec3-11ea-9396-c8ba170c33cf.png)


