### PR TITLE
fix: [XEUS-1130] Fix UsageBarLimit value.

### DIFF
--- a/docs/content/components/usage-bar.mdx
+++ b/docs/content/components/usage-bar.mdx
@@ -63,5 +63,7 @@ date: 2019-06-06
   <UsageBar now={0} isByte />
   <UsageBar now={0} isBulk />
   <UsageBar percent={0} />
+  <UsageBar isByte percent={0} max={0} />
+  <UsageBar isBulk percent={0} max={0} />
 </div>
 ```

--- a/src/components/UsageBar/index.tsx
+++ b/src/components/UsageBar/index.tsx
@@ -72,8 +72,8 @@ const UsageBar: React.FC<UsageBarProps> = props => {
       nowSuffix = nowArr[1];
     }
     const maxArr: any = max && xbytes(max, byteOptions);
-    maxValue = maxArr[0];
-    maxSuffix = maxArr[1];
+    maxValue = maxArr[0] === undefined ? 0 : maxArr[0];
+    maxSuffix = maxArr[1] === undefined ? 'B' : maxArr[1];
   } else if (isBulk) {
     // hasPercent 表明左边数据设置完成（百分比形式），不需要再调整
     if (!hasPercent && now) {
@@ -82,8 +82,8 @@ const UsageBar: React.FC<UsageBarProps> = props => {
       nowSuffix = nowArr[1] as string;
     }
     const maxArr: any = max && bulk(max, { splitUnit: true });
-    maxValue = maxArr[0];
-    maxSuffix = maxArr[1];
+    maxValue = maxArr[0] === undefined ? 0 : maxArr[0];
+    maxSuffix = maxArr[1] === undefined ? '' : maxArr[1];
   }
 
   // max 为 0 时，设置为无限制


### PR DESCRIPTION
Signed-off-by: zghzzj <2627191377@qq.com>

## 问题
![image](https://user-images.githubusercontent.com/34362276/77994528-c3f4b080-735c-11ea-98da-03ebc05767d4.png)

- bug 原因
项目中
![image](https://user-images.githubusercontent.com/34362276/77994616-eab2e700-735c-11ea-9927-e2277efc4c90.png)

![image](https://user-images.githubusercontent.com/34362276/77994670-ff8f7a80-735c-11ea-8658-c0819314bd50.png)

docs测试
```
...
...
...
<UsageBar isByte max={0} />
<UsageBar isBulk max={0} /> 
```

![image](https://user-images.githubusercontent.com/34362276/78679174-78be3d00-791c-11ea-8b30-e91aff128e5b.png)



- 解决结果

![image](https://user-images.githubusercontent.com/34362276/78000108-5483be80-7366-11ea-9ad2-c4c98041a05d.png)

![image](https://user-images.githubusercontent.com/34362276/78678850-15cca600-791c-11ea-9353-3841e6e535f5.png)

issue
http://issue.xsky.com/browse/XEUS-1130


