### PR TITLE
fix: Tabs only show string title.

### DIFF
--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -57,7 +57,7 @@ const Tabs: React.FC<TabsProps> = props => {
           <Nav bsStyle="tabs">
             {tabsFrontList.map((tab, idx) => (
               <NavItem
-                title={tab['title']}
+                title={typeof tab['title'] === 'string' ? tab['title'] : undefined}
                 key={eventKeyName ? tab[eventKeyName] : idx}
                 eventKey={eventKeyName ? tab[eventKeyName] : idx}
               >


### PR DESCRIPTION
Signed-off-by: wuruii <wurui@xsky.com>

http://issue.xsky.com/browse/WIZARD-5318

![image](https://user-images.githubusercontent.com/39052905/81524046-6489b780-9382-11ea-9665-a1b79c111b27.png)
![image](https://user-images.githubusercontent.com/39052905/81524060-6f444c80-9382-11ea-970d-a87938c4b3ea.png)
