### PR TITLE
fix remove tab max-width.

### DIFF
--- a/src/components/Tabs/style.scss
+++ b/src/components/Tabs/style.scss
@@ -41,7 +41,6 @@
     &.dropdown-toggle {
       position: relative;
       padding-right: 30px;
-      max-width: 150px;
 
       & .caret {
         position: absolute;


### PR DESCRIPTION
Signed-off-by: genghai <genghai@xsky.com>

#移除“更多” 盒子宽度限制
解决国际化英文单词过长换行问题
- 修改前
![image](https://user-images.githubusercontent.com/34362276/88531668-c975b500-d035-11ea-9df3-bd9450216a9f.png)
- 修改后
![image](https://user-images.githubusercontent.com/34362276/88531758-ed38fb00-d035-11ea-81a2-7375704790da.png)
