### PR TITLE
improve: Remove styles not belong to UsageBar.

### DIFF
--- a/src/components/UsageBar/style.scss
+++ b/src/components/UsageBar/style.scss
@@ -93,34 +93,3 @@
   background-color: $gray-lighter-5;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
 }
-
-.PercentStack__tooltip-item {
-  padding: 5px;
-  position: relative;
-  padding-left: 20px;
-  .items::before {
-    content: '';
-    position: absolute;
-    left: 2px;
-    top: 10px;
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background-color: $white;
-    border: 1px solid $white;
-  }
-  .item-0::before {
-    display: none;
-  }
-
-  .item-1::before {
-    border-color: $purple-normal;
-    background-color: $purple-normal;
-  }
-
-  .item-2::before {
-    border-color: $gray-medium-10;
-    background-color: $gray-medium-10;
-  }
-}
-


### PR DESCRIPTION
Signed-off-by: wuruii <wurui@xsky.com>

移除 UsageBar 中 PercentStack__tooltip-item 相关的样式，UsageBar tooltip 样式在 wizard UsageWrapper 组件中实现

![image](https://user-images.githubusercontent.com/39052905/108488941-f04e4e00-72db-11eb-82e6-964493a5110f.png)
