### PR TITLE
fix: Close calendar picker on blur

### DIFF
--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -34,6 +34,7 @@ const DatePicker: React.FC<DatePickerProps> = props => {
     lang,
   } = props;
   const [val, setVal] = React.useState();
+  const calendarContainerRef = React.useRef<HTMLDivElement>(null);
   const handleChange = React.useCallback(
     (value: Moment) => {
       setVal(value);
@@ -53,6 +54,7 @@ const DatePicker: React.FC<DatePickerProps> = props => {
       showToday={false}
     />
   );
+  const getCalendarContainer = () => calendarContainerRef.current;
 
   return (
     <RCDatePicker
@@ -61,6 +63,7 @@ const DatePicker: React.FC<DatePickerProps> = props => {
       calendar={calendar}
       value={reset ? null : val || (defaultValue && moment(defaultValue))}
       onChange={handleChange}
+      getCalendarContainer={getCalendarContainer}
     >
       {({ value }: any) => {
         return (
@@ -71,6 +74,7 @@ const DatePicker: React.FC<DatePickerProps> = props => {
               readOnly
               value={(value && value.format(getFormat(showTime))) || ''}
             />
+            <div ref={calendarContainerRef} />
           </span>
         );
       }}


### PR DESCRIPTION

 https://github.com/react-component/calendar/commit/46fc91eaffece4486cc60d25821f3745a444878f?diff=split
rc-calendar 版本改动，修复modal里日期选择框打开就闪退的问题