### PR TITLE
fix: Modal close icon can not click

### DIFF
--- a/src/components/Modal/style.scss
+++ b/src/components/Modal/style.scss
@@ -1,4 +1,10 @@
 .Modal {
+  .modal-header{
+    .close {
+      // 添加定位属性，让 close 的 icon 在 drag-handle上层
+      position: relative;
+    }
+  }
   .modal-body {
     padding: 24px 50px 0 50px;
   }


### PR DESCRIPTION
Signed-off-by: zhanghuan <zhang.huan@xsky.com>

## 描述 - Modal 的关闭按钮在某些场景下无法点击

当关闭 icon 的样式 opacity 被覆盖为1时，无法点击。
解决方式：通过 position: 'relative' 设置 icon 的层级

复现截图：
![bug](https://user-images.githubusercontent.com/113670299/190976002-f367b12d-46d9-40fa-a063-daf9ee455177.png)
