### PR TITLE
fix: Draggable Modal moves the browser scroll bar

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,20 +1,13 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import {
-  Modal as BaseModal,
-  ModalHeader,
-  ModalTitle,
-  ModalBody,
-  ModalFooter,
-  Button,
-} from 'react-bootstrap';
+import { Modal as BaseModal, ModalHeader, ModalTitle, ModalBody, ModalFooter, Button } from 'react-bootstrap';
 import Draggable, { DraggableEvent, DraggableData } from 'react-draggable';
 import { ModalProps } from '../../interface';
 import Loader from '../Loader';
 
 import './style.scss';
 
-const useDrag = ()=>{
+const useDrag = () => {
   const [bounds, setBounds] = React.useState({ left: 0, top: 0, bottom: 0, right: 0 });
   const draggleRef = React.useRef<HTMLDivElement>(null);
   const onStart = (_event: DraggableEvent, uiData: DraggableData) => {
@@ -36,17 +29,17 @@ const useDrag = ()=>{
   return {
     draggleRef,
     onStart,
-    bounds
+    bounds,
   };
-}
+};
 
 // 保持容器高度不塌陷
 const draggableHiddenTitleStyle: React.CSSProperties = {
-  visibility: 'hidden'
+  visibility: 'hidden',
 };
 
-const Modal: React.FC<ModalProps> = props => {
-  const {onStart, bounds, draggleRef} = useDrag();
+const Modal: React.FC<ModalProps> = (props) => {
+  const { onStart, bounds, draggleRef } = useDrag();
 
   const {
     title,
@@ -61,7 +54,7 @@ const Modal: React.FC<ModalProps> = props => {
     hideFooter,
     hideHeader,
     draggable = true,
-    preventDragByTitle
+    preventDragByTitle,
   } = props;
   let { bsSize } = props,
     dialogClassName = '';
@@ -71,31 +64,36 @@ const Modal: React.FC<ModalProps> = props => {
   }
 
   // 让 title 在可拖动模块的上层，来使title区域的拖动效果失效
-  const modalTitleStyle = React.useMemo<React.CSSProperties>(() => (draggable && preventDragByTitle ? { position: 'absolute' } : {}), [draggable, preventDragByTitle]);
+  const modalTitleStyle = React.useMemo<React.CSSProperties>(
+    () => (draggable && preventDragByTitle ? { position: 'absolute' } : {}),
+    [draggable, preventDragByTitle],
+  );
 
   return (
-    <Draggable
-      disabled={!draggable}
-      bounds={bounds}
-      handle=".drag-handle"
-      onStart={(event, uiData) => onStart(event, uiData)}
+    <BaseModal
+      bsSize={bsSize}
+      className="Modal"
+      dialogClassName={dialogClassName}
+      style={style}
+      backdrop="static"
+      onHide={onHide}
+      show={show}
     >
-      <BaseModal
-        bsSize={bsSize}
-        className="Modal"
-        dialogClassName={dialogClassName}
-        style={style}
-        backdrop="static"
-        onHide={onHide}
-        show={show}
+      <Draggable
+        disabled={!draggable}
+        bounds={bounds}
+        handle=".drag-handle"
+        onStart={(event, uiData) => onStart(event, uiData)}
       >
-        <div ref={draggleRef}>
-          {draggable && <div className="drag-handle" ref={draggleRef}/>}
+        <div ref={draggleRef} className="modal-content">
+          {draggable && <div className="drag-handle" />}
           <div>
             {!hideHeader && (
               <ModalHeader key="header" closeButton>
                 <ModalTitle style={modalTitleStyle}>{title}</ModalTitle>
-                {draggable && preventDragByTitle ?  <ModalTitle style={draggableHiddenTitleStyle}>{title}</ModalTitle> : null}
+                {draggable && preventDragByTitle ? (
+                  <ModalTitle style={draggableHiddenTitleStyle}>{title}</ModalTitle>
+                ) : null}
               </ModalHeader>
             )}
           </div>
@@ -110,8 +108,8 @@ const Modal: React.FC<ModalProps> = props => {
             </ModalFooter>
           )}
         </div>
-      </BaseModal>
-    </Draggable>
+      </Draggable>
+    </BaseModal>
   );
 };
 

--- a/src/components/Modal/style.scss
+++ b/src/components/Modal/style.scss
@@ -1,4 +1,11 @@
 .Modal {
+  // 修复添加拖动功能后，滚动条跟随的bug
+  // 覆盖原有 .modal-content的样式，让拖动的dom显示其样式
+  .modal-dialog > .modal-content{
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+  }
   .modal-header{
     .close {
       // 添加定位属性，让 close 的 icon 在 drag-handle上层


### PR DESCRIPTION
Signed-off-by: zhanghuan <zhang.huan@xsky.com>

## 描述 - Modal组件拖动时，滚动条跟随问题
思路：改变拖动的对象为滚动条内部的元素。目前版本 react- bootstrap 不支持把用 React 组件嵌套 Modal 的内容部分，创造一个新的dom作为拖动的容器，设置class为 ‘.modal-content’ 以保持样式。为避免2份样式再覆盖原本的 .modal-content 样式。

自测截图：
![image1](https://user-images.githubusercontent.com/113670299/192147125-fc64ceda-90ca-44ac-ba52-52a07b51abaa.png)
