### PR TITLE
fix: update UsageBar to show percent when max is 0 and zero max shown

### DIFF
--- a/src/components/UsageBar/index.tsx
+++ b/src/components/UsageBar/index.tsx
@@ -82,7 +82,9 @@ const UsageBar: React.FC<UsageBarProps> = props => {
       break;
     default:
       const now = hasNow ? props.now : props.percent && max && props.percent * max;
-      const percent = hasPercent ? props.percent : max ? props.now && props.now / max : 0;
+      // 当展示右侧 max 为 0+单位时(showZeroMax为true), 如果 now 大于 max 时，percent 应为 100%
+      const defaultPercent = showZeroMax && Number(now) > Number(max) ? 1 : 0;
+      const percent = hasPercent ? props.percent : max ? props.now && props.now / max : defaultPercent;
       const errorPercent = unavailableData && max && unavailableData / max;
       let nowValue: number | string | undefined = now;
       let maxValue: number | string | undefined = max;

--- a/stories/UsageBar.stories.tsx
+++ b/stories/UsageBar.stories.tsx
@@ -68,6 +68,8 @@ storiesOf('DATA SHOW | UsageBar', module)
       <UsageBar percent={0} isByte />
       <UsageBar percent={0} isBulk />
       <UsageBar percent={0} />
+      <UsageBar now={55} max={0} showZeroMax isByte />
+      <UsageBar now={1} max={0} showZeroMax isBulk />
     </>
   ))
   .add('series', () => (


### PR DESCRIPTION
#### UsageBar需要满足这种情况：右侧max需要显示0时，如果now > max，percent应该为1，颜色为danger
- storybook
![image](https://user-images.githubusercontent.com/13409910/209604108-a172183b-9579-4150-a5b5-c010ca3fd343.png)

- 真实环境 http://10.16.13.216:8056/
![image](https://user-images.githubusercontent.com/13409910/209604048-9f1ebb89-1ff8-40e0-954e-ba1f6ec51ba0.png)

相关issue: [配置桶容量配额或者对象配额为0，桶内容量或者对象数超过配额后，界面未更新为对应的颜色](https://issue.xsky.com/browse/XEOS-5560)