### PR TITLE
refactor: upgrade modal

### DIFF
--- a/src/components/Modal/index.test.tsx
+++ b/src/components/Modal/index.test.tsx
@@ -37,6 +37,20 @@ describe('Modal', () => {
         .props().style,
     ).toEqual({ color: 'red' });
   });
+  it('size is xlarge', () => {
+    const node = mount(
+      <Modal title="Modal Title" onHide={noOp} bsSize="xlarge" show>
+        <strong>Modal Content</strong>
+      </Modal>,
+    );
+    expect(
+      node
+        .find('ModalDialog')
+        .at(0)
+        // @ts-ignore
+        .props().dialogClassName,
+    ).toEqual('modal-xlg');
+  });
   it('hide footer', () => {
     const node = mount(
       <Modal title="Modal Title" onHide={noOp} hideFooter show>

--- a/src/components/Modal/index.test.tsx
+++ b/src/components/Modal/index.test.tsx
@@ -37,20 +37,6 @@ describe('Modal', () => {
         .props().style,
     ).toEqual({ color: 'red' });
   });
-  it('size is xlarge', () => {
-    const node = mount(
-      <Modal title="Modal Title" onHide={noOp} bsSize="xlarge" show>
-        <strong>Modal Content</strong>
-      </Modal>,
-    );
-    expect(
-      node
-        .find('ModalDialog')
-        .at(0)
-        // @ts-ignore
-        .props().dialogClassName,
-    ).toEqual('modal-xlg');
-  });
   it('hide footer', () => {
     const node = mount(
       <Modal title="Modal Title" onHide={noOp} hideFooter show>

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -55,11 +55,10 @@ const Modal: React.FC<ModalProps> = props => {
     hideHeader,
     draggable = true,
     preventDragByTitle,
+    centered,
   } = props;
-  let { bsSize } = props,
-    dialogClassName = '';
-  if (bsSize === 'xl') {
-    dialogClassName = 'modal-xlg';
+  let { bsSize } = props;
+  if (bsSize === 'medium') {
     bsSize = undefined;
   }
 
@@ -71,12 +70,12 @@ const Modal: React.FC<ModalProps> = props => {
   return (
     <BaseModal
       className="Modal"
-      dialogClassName={dialogClassName}
       style={style}
       size={bsSize}
       backdrop="static"
       onHide={onHide}
       show={show}
+      centered={centered}
     >
       <Draggable
         disabled={!draggable}
@@ -87,11 +86,16 @@ const Modal: React.FC<ModalProps> = props => {
         <div ref={draggleRef} className="modal-content">
           {draggable && <div className="drag-handle" />}
           {!hideHeader && (
-            <BaseModal.Header key="header" closeButton>
+            <BaseModal.Header key="header" closeButton={false}>
               <BaseModal.Title style={modalTitleStyle}>{title}</BaseModal.Title>
               {draggable && preventDragByTitle ? (
                 <BaseModal.Title style={draggableHiddenTitleStyle}>{title}</BaseModal.Title>
               ) : null}
+              <div className="close" onClick={onHide}>
+                <span aria-hidden="true" className="close-icon">
+                  ×
+                </span>
+              </div>
             </BaseModal.Header>
           )}
 
@@ -124,7 +128,7 @@ Modal.propTypes = {
   /** 对话框附加行内样式 */
   style: PropTypes.object,
   /** 对话框大小 */
-  bsSize: PropTypes.oneOf(['sm', 'lg', 'xl', undefined, null]),
+  bsSize: PropTypes.oneOf(['sm', 'lg', 'medium', undefined, null]),
   /** 确定、提交按钮文案 */
   confirmText: PropTypes.string,
   /** 确定、提交按钮样式 */
@@ -139,6 +143,8 @@ Modal.propTypes = {
   draggable: PropTypes.bool,
   /** 在title区域禁掉拖拽功能 */
   preventDragByTitle: PropTypes.bool,
+  /** 是否应垂直居中 */
+  centered: PropTypes.bool,
 };
 
 Modal.defaultProps = {

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -58,8 +58,13 @@ const Modal: React.FC<ModalProps> = props => {
     centered,
   } = props;
   let { bsSize } = props;
+  let dialogClassName = '';
   if (bsSize === 'medium') {
     bsSize = undefined;
+  }
+  if (bsSize === 'xlarge') {
+    bsSize = undefined;
+    dialogClassName = 'modal-xlg';
   }
 
   // 让 title 在可拖动模块的上层，来使title区域的拖动效果失效
@@ -71,6 +76,7 @@ const Modal: React.FC<ModalProps> = props => {
     <BaseModal
       className="Modal"
       style={style}
+      dialogClassName={dialogClassName}
       size={bsSize}
       backdrop="static"
       onHide={onHide}
@@ -128,7 +134,7 @@ Modal.propTypes = {
   /** 对话框附加行内样式 */
   style: PropTypes.object,
   /** 对话框大小 */
-  bsSize: PropTypes.oneOf(['sm', 'lg', 'medium', undefined, null]),
+  bsSize: PropTypes.oneOf(['sm', 'lg', 'medium', 'xlarge', undefined, null]),
   /** 确定、提交按钮文案 */
   confirmText: PropTypes.string,
   /** 确定、提交按钮样式 */

--- a/src/components/Modal/style.scss
+++ b/src/components/Modal/style.scss
@@ -8,10 +8,25 @@
     border: none !important;
     box-shadow: none !important;
   }
+  .modal-content {
+    -webkit-box-shadow: 0 5px 15px rgba($black, .5);
+    box-shadow: 0 5px 15px rgba($black, .5);
+  }
   .modal-header{
+    .modal-title {
+      font-size: $font-size-16;
+    }
     .close {
       // 添加定位属性，让 close 的 icon 在 drag-handle上层
       position: relative;
+      height: 25px;
+      margin-top: -11px;
+      .close-icon {
+        font-size: 21px;
+        color: $black;
+        opacity: 0.2;
+        cursor: pointer;
+      }
     }
   }
   .modal-body {

--- a/src/components/Modal/style.scss
+++ b/src/components/Modal/style.scss
@@ -49,4 +49,16 @@
     top: -5px;
     cursor: move;
   }
+  @media (min-width: 1225px) {
+    .modal-xlg {
+      width: 1200px;
+      max-width: none;
+    }
+  }
+  @media (max-width: 1224px) and (min-width: 992px) {
+    .modal-xlg {
+      width: 900px;
+      max-width: none;
+    }
+  }
 }

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 // import { SelectCallback, Sizes } from 'react-bootstrap';
 import { Moment } from 'moment';
-import { ButtonProps as BsButtonProps } from 'react-bootstrap/Button';
+import { ModalProps as BsModalProps, ButtonProps as BsButtonProps } from 'react-bootstrap';
 import CSS from 'csstype';
 
 export interface Map<K, V> {
@@ -132,13 +132,10 @@ export interface StepsProps {
   iconStatus?: string;
 }
 
-export interface ModalProps {
+export interface ModalProps extends BsModalProps {
   title: string;
-  onHide: any;
-  onOk?: any;
-  show?: boolean;
-  style?: React.CSSProperties;
-  bsSize?: 'sm' | 'lg' | 'medium';
+  onOk?: () => void;
+  bsSize?: 'sm' | 'medium' | 'lg' | 'xlarge';
   confirmText?: string;
   okStyle?: string;
   loading?: boolean;
@@ -146,7 +143,6 @@ export interface ModalProps {
   hideHeader?: boolean;
   draggable?: boolean;
   preventDragByTitle?: boolean;
-  centered?: boolean;
 }
 
 interface SwitchInput {

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -138,7 +138,7 @@ export interface ModalProps {
   onOk?: any;
   show?: boolean;
   style?: React.CSSProperties;
-  bsSize?: 'sm' | 'lg' | 'xl';
+  bsSize?: 'sm' | 'lg' | 'medium';
   confirmText?: string;
   okStyle?: string;
   loading?: boolean;
@@ -146,6 +146,7 @@ export interface ModalProps {
   hideHeader?: boolean;
   draggable?: boolean;
   preventDragByTitle?: boolean;
+  centered?: boolean;
 }
 
 interface SwitchInput {

--- a/src/style/bootstrap-custom.scss
+++ b/src/style/bootstrap-custom.scss
@@ -1390,10 +1390,10 @@ $badge-border-radius:               $border-radius !default;
 // scss-docs-start modal-variables
 $modal-inner-padding:               $spacer !default;
 
-$modal-footer-margin-between:       .5rem !default;
+$modal-footer-margin-between:       0 !default;
 
 $modal-dialog-margin:               .5rem !default;
-$modal-dialog-margin-y-sm-up:       1.75rem !default;
+$modal-dialog-margin-y-sm-up:       30px !default;
 
 $modal-title-line-height:           $line-height-base !default;
 
@@ -1413,15 +1413,15 @@ $modal-header-border-color:         var(--#{$prefix}border-color) !default;
 $modal-header-border-width:         $modal-content-border-width !default;
 $modal-header-padding-y:            $modal-inner-padding !default;
 $modal-header-padding-x:            $modal-inner-padding !default;
-$modal-header-padding:              $modal-header-padding-y $modal-header-padding-x !default; // Keep this for backwards compatibility
+$modal-header-padding:              15px 18px 12px 50px !default; // Keep this for backwards compatibility
 
 $modal-footer-bg:                   null !default;
 $modal-footer-border-color:         $modal-header-border-color !default;
 $modal-footer-border-width:         $modal-header-border-width !default;
 
 $modal-sm:                          300px !default;
-$modal-md:                          500px !default;
-$modal-lg:                          800px !default;
+$modal-md:                          700px !default;
+$modal-lg:                          900px !default;
 $modal-xl:                          1140px !default;
 
 $modal-fade-transform:              translate(0, -50px) !default;


### PR DESCRIPTION
升级前：
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/70199559/235049232-8f8e3e8c-06c7-44a0-852d-b89537b118c2.png">
升级后：
<img width="1036" alt="image" src="https://user-images.githubusercontent.com/70199559/235049282-7b4ad791-cd3e-48f3-ae90-c1af62485675.png">
属性变更：
- 新增 centered ，可以使得 Modal 垂直居中

样式变更：
- modal 的圆角之前规范设置遗漏了，这次改为 4px
- xlarge 样式被迁移到 wizard-ui里，