### PR TITLE
refactor: upgrade dropdownButton

### DIFF
--- a/src/components/Dropdown/index.test.tsx
+++ b/src/components/Dropdown/index.test.tsx
@@ -8,6 +8,6 @@ describe('Dropdown', () => {
     const title = dropdown.find('button');
     expect(dropdown.find('div.dropdown').length).toBe(1);
     title.simulate('click');
-    expect(dropdown.find('div.dropdown.open').length).toBe(1);
+    expect(dropdown.find('div.dropdown.show').length).toBe(1);
   });
 });

--- a/src/components/DropdownButton/index.test.tsx
+++ b/src/components/DropdownButton/index.test.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import DropdownButton from './index';
 import { mount } from 'enzyme';
-import { Sizes } from 'react-bootstrap';
-
+import { ButtonSizes } from '../../interface';
 describe('Dropdown', () => {
   it('should render corrent size', () => {
-    const sizes: Sizes[] = ['lg', 'sm', 'xs'];
+    const sizes: ButtonSizes[] = ['lg', 'sm', 'xs'];
     const classNames = [
       '.dropdown.btn-group.btn-group-lg',
       '.dropdown.btn-group.btn-group-sm',
       '.dropdown.btn-group.btn-group-xs',
     ];
     sizes.forEach((size, index) => {
-      const dropdown = mount(<DropdownButton id="a1" bsSize={size} title="size" />);
+      const dropdown = mount(<DropdownButton id="a1" size={size} title="size" />);
       expect(dropdown.find(classNames[index]).length).toBe(1);
     });
   });
@@ -27,7 +26,7 @@ describe('Dropdown', () => {
       '.dropdown.btn-group.btn-group-danger',
     ];
     styles.forEach((style, index) => {
-      const dropdown = mount(<DropdownButton id="a1" bsStyle={style} title="style" />);
+      const dropdown = mount(<DropdownButton id="a1" variant={style} title="style" />);
       expect(dropdown.find(classNames[index]).length).toBe(1);
     });
   });
@@ -45,7 +44,7 @@ describe('Dropdown', () => {
     expect(dropdown.find('span.caret').length).toBe(0);
   });
   it('should render corrent pullRight', () => {
-    const dropdown = mount(<DropdownButton id="a1" pullRight title="pullRight" />);
+    const dropdown = mount(<DropdownButton id="a1" align="end" title="pullRight" />);
     expect(dropdown.find('.dropdown-menu.dropdown-menu-right').length).toBe(1);
   });
 });

--- a/src/components/DropdownButton/index.tsx
+++ b/src/components/DropdownButton/index.tsx
@@ -53,7 +53,7 @@ function renderMenu(
     return (
       <Dropdown.Item
         key={item}
-        onSelect={() => {
+        onClick={() => {
           setButtonOpen(!!open);
         }}
       >
@@ -93,10 +93,13 @@ function renderMenu(
 
 const DropdownButton = (props: DropdownButtonProps) => {
   const getContainerClass = () => {
-    const { modifer } = props;
+    const { modifer, noCaret } = props;
     let className = 'dropdown-container';
     if (modifer) {
       className += ' ' + modifer;
+    }
+    if (noCaret) {
+      className += ' ' + 'dropdown-noCaret';
     }
     return className;
   };
@@ -110,32 +113,43 @@ const DropdownButton = (props: DropdownButtonProps) => {
     if (onToggle) onToggle(isOpen);
   };
 
-  const { bsStyle, id, onSelect, title, menu, children, componentClass, open } = props;
+  const {
+    bsStyle,
+    id,
+    dropup,
+    onSelect,
+    title,
+    menu,
+    children,
+    componentClass,
+    open,
+    bsSize,
+    disabled,
+    pullRight,
+  } = props;
 
   const prevMenu = usePrevious(menu);
   const isDifferentMenu = prevMenu !== menu;
-  const allBoolProps = ['disabled', 'dropup', 'noCaret', 'open', 'pullRight'];
-  const boolProps = {};
   const [buttonOpen, setButtonOpen] = React.useState<boolean>(!!open);
 
-  allBoolProps.forEach(prop => {
-    if (props.hasOwnProperty(prop)) {
-      boolProps[prop] = props[prop];
-    }
-  });
   const containerClassName = getContainerClass();
+  const drop = dropup ? 'up' : 'down';
+  const align = pullRight ? 'end' : undefined;
+  const show = props.hasOwnProperty('open') ? open : buttonOpen;
   return (
     <BootstrapDropdownButton
-      {...(boolProps as any)}
       variant={bsStyle}
       id={id}
       onSelect={onSelect}
       title={title}
-      // bsSize={bsSize}
+      size={bsSize}
+      disabled={disabled}
+      drop={drop}
+      align={align}
       onToggle={(isOpen: boolean) => getOnToggle(isOpen)}
-      componentClass={componentClass}
+      as={componentClass}
       className={containerClassName}
-      open={props.hasOwnProperty('open') ? open : buttonOpen}
+      show={show}
     >
       {menu ? renderContent(menu, setButtonOpen, isDifferentMenu, open) : children}
     </BootstrapDropdownButton>
@@ -202,7 +216,7 @@ DropdownButton.propTypes = {
   /**
    * 大小 string，支持large，default，small，xsmall，默认为default
    **/
-  bsSize: PropTypes.oneOf(['xs', 'sm', 'medium', 'lg']),
+  bsSize: PropTypes.oneOf(['sm', 'lg']),
   /**
    * 下拉框显示内容 string|element
    **/

--- a/src/components/DropdownButton/style.scss
+++ b/src/components/DropdownButton/style.scss
@@ -9,7 +9,7 @@
   min-width: auto;
   border: 1px solid $border-2;
   border-top: 3px solid $primary-normal;
-  box-shadow: 0 1px 8px rgba(black,0.12);
+  box-shadow: 0 1px 8px rgba(black, 0.12);
   &>a {
     text-decoration: none;
     line-height: 24px;
@@ -37,11 +37,10 @@
       cursor: not-allowed;
     }
     &:not(.disabled):hover {
-      color: #262626;
+      color: $text-1;
     }
     &:not(.disabled):focus {
-      color: #262626;
-      outline: 5px auto -webkit-focus-ring-color;
+      color: $text-1;
       outline-offset: -2px;
     }
   }

--- a/src/components/DropdownButton/style.scss
+++ b/src/components/DropdownButton/style.scss
@@ -1,26 +1,23 @@
 @import '../../style/variables.scss';
 
-.detail-toolbar + .dropdown-menu,
-.list-toolbar + .dropdown-menu,
-.table-toolbar + .dropdown-menu,
-.detail-toolbar + .dropdown-menu .dropdown-menu,
-.list-toolbar + .dropdown-menu .dropdown-menu,
-.table-toolbar + .dropdown-menu .dropdown-menu {
+.detail-toolbar .dropdown-menu,
+.list-toolbar .dropdown-menu,
+.table-toolbar .dropdown-menu,
+.detail-toolbar .dropdown-menu,
+.list-toolbar .dropdown-menu,
+.table-toolbar .dropdown-menu {
   min-width: auto;
   border: 1px solid $border-2;
   border-top: 3px solid $primary-normal;
   box-shadow: 0 1px 8px rgba(black,0.12);
-  &>li>a {
+  &>a {
     text-decoration: none;
     line-height: 24px;
   }
   /*------ 分割线状态样式--------*/
-  &>li.divider {
+  &>hr.dropdown-divider {
     color: $border-2;
     margin: 3px 20px;
-  }
-  .SubMenu li {
-    color: $text-2;
   }
 }
 .dropup .dropdown-menu {
@@ -29,8 +26,26 @@
   border-top: 1px solid $border-2;
   border-bottom: 3px solid $primary-normal;
 }
-.scroll-toolbar + .dropdown-menu,
-.scroll-toolbar + .dropdown-menu .dropdown-menu {
+.scroll-toolbar .dropdown-menu {
   max-height: 300px;
   overflow-y: auto;
+}
+.dropdown-container {
+  .dropdown-item {
+    &.disabled {
+      pointer-events: auto;
+      cursor: not-allowed;
+    }
+    &:not(.disabled):hover {
+      color: #262626;
+    }
+    &:not(.disabled):focus {
+      color: #262626;
+      outline: 5px auto -webkit-focus-ring-color;
+      outline-offset: -2px;
+    }
+  }
+  &.dropdown-noCaret .dropdown-toggle::after {
+    display: none;
+  }
 }

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 // import { SelectCallback, Sizes } from 'react-bootstrap';
 import { Moment } from 'moment';
-import { ButtonProps as BsButtonProps } from 'react-bootstrap/Button';
+import {
+  ButtonProps as BsButtonProps,
+  DropdownButtonProps as BsDropdownButtonProps,
+} from 'react-bootstrap';
 import CSS from 'csstype';
 
 export interface Map<K, V> {
@@ -211,17 +214,17 @@ export type DropdownButtonMenuItem =
 export interface DefaultDropdownButtonProps {
   componentClass: any;
 }
-export interface DropdownButtonProps extends DefaultDropdownButtonProps {
+export interface DropdownButtonProps
+  extends DefaultDropdownButtonProps,
+    Omit<BsDropdownButtonProps, 'children' | 'title'> {
   bsStyle?: string;
-  id: string;
-  onSelect?: any;
   onToggle?: (isOpen: boolean) => void;
+  // TODO @fmw
   bsSize?: any;
   title?: string | React.ReactNode;
   menu?: DropdownButtonMenuItem[];
   children?: React.ReactNode;
   modifer?: string;
-  disabled?: boolean;
   dropup?: boolean;
   noCaret?: boolean;
   open?: boolean;

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -2,11 +2,9 @@ import * as React from 'react';
 // import { SelectCallback, Sizes } from 'react-bootstrap';
 import { Moment } from 'moment';
 import {
-  ButtonProps as BsButtonProps,
-  DropdownButtonProps as BsDropdownButtonProps,
   ModalProps as BsModalProps,
+  DropdownButtonProps as BsDropdownButtonProps,
 } from 'react-bootstrap';
-import { ModalProps as BsModalProps } from 'react-bootstrap';
 import { ButtonProps as BaseButtonProps } from '@restart/ui/Button';
 import { ButtonVariant } from '../node_modules/react-bootstrap/esm/types';
 import CSS from 'csstype';
@@ -214,24 +212,15 @@ export type DropdownButtonMenuItem =
     }
   | string;
 
-export interface DefaultDropdownButtonProps {
-  componentClass: any;
-}
-export interface DropdownButtonProps
-  extends DefaultDropdownButtonProps,
-    Omit<BsDropdownButtonProps, 'children' | 'title'> {
-  bsStyle?: string;
-  onToggle?: (isOpen: boolean) => void;
-  // TODO @fmw
-  bsSize?: any;
-  title?: string | React.ReactNode;
+export type ButtonSizes = 'sm' | 'lg' | 'xs';
+
+export interface DropdownButtonProps extends Omit<BsDropdownButtonProps, 'children' | 'size'> {
+  onToggle?: (isShow: boolean) => void;
   menu?: DropdownButtonMenuItem[];
   children?: React.ReactNode;
   modifer?: string;
-  dropup?: boolean;
   noCaret?: boolean;
-  open?: boolean;
-  pullRight?: boolean;
+  size?: ButtonSizes;
 }
 
 export interface NavigationGroup {
@@ -450,9 +439,9 @@ export interface ButtonProps extends BaseButtonProps {
   block?: boolean;
   active?: boolean;
   variant?: ButtonVariant;
-  size?: 'sm' | 'lg' | 'xs';
+  size?: ButtonSizes;
 }
 
-export interface HeaderToggleProps{
-  eventKey: string
+export interface HeaderToggleProps {
+  eventKey: string;
 }

--- a/src/style/bootstrap-custom.scss
+++ b/src/style/bootstrap-custom.scss
@@ -502,7 +502,7 @@ $border-radius-pill:          50rem !default;
 // scss-docs-end border-radius-variables
 
 // scss-docs-start box-shadow-variables
-$box-shadow:                  0 .5rem 1rem rgba($black, .15) !default;
+$box-shadow:                  0 5px 15px rgba($black, .5) !default;
 $box-shadow-sm:               0 .125rem .25rem rgba($black, .075) !default;
 $box-shadow-lg:               0 1rem 3rem rgba($black, .175) !default;
 $box-shadow-inset:            inset 0 1px 2px rgba($black, .075) !default;
@@ -1129,9 +1129,9 @@ $navbar-dark-brand-hover-color:     $navbar-dark-active-color !default;
 // Dropdown menu container and contents.
 
 // scss-docs-start dropdown-variables
-$dropdown-min-width:                10rem !default;
+$dropdown-min-width:                160px !default;
 $dropdown-padding-x:                0 !default;
-$dropdown-padding-y:                .5rem !default;
+$dropdown-padding-y:                5px !default;
 $dropdown-spacer:                   .125rem !default;
 $dropdown-font-size:                $font-size-base !default;
 $dropdown-color:                    $body-color !default;
@@ -1148,13 +1148,13 @@ $dropdown-link-color:               $text-2 !default;
 $dropdown-link-hover-color:         shade-color($dropdown-link-color, 10%) !default;
 $dropdown-link-hover-bg:            $bg-2-hover !default;
 
-$dropdown-link-active-color:        $component-active-color !default;
-$dropdown-link-active-bg:           $component-active-bg !default;
+$dropdown-link-active-color:        shade-color($dropdown-link-color, 10%) !default;
+$dropdown-link-active-bg:           $bg-2-hover !default;
 
 $dropdown-link-disabled-color:      rgba($text-2, 0.4) !default;
 
-$dropdown-item-padding-y:           $spacer * .25 !default;
-$dropdown-item-padding-x:           $spacer !default;
+$dropdown-item-padding-y:           3px !default;
+$dropdown-item-padding-x:           20px !default;
 
 $dropdown-header-color:             $gray-600 !default;
 $dropdown-header-padding-x:         $dropdown-item-padding-x !default;

--- a/stories/DropdownButton.stories.tsx
+++ b/stories/DropdownButton.stories.tsx
@@ -8,48 +8,48 @@ storiesOf('DropdownButton', module)
   .add('size', () => (
     <div>
       <DropdownButtonDemo />
-      <DropdownButton id="a1" bsSize="large" title="large" menu={['menu1', 'menu2', 'menu3']} />
+      <DropdownButton id="a1" size="lg" title="lg" menu={['menu1', 'menu2', 'menu3']} />
       <DropdownButton id="a2" title="default" menu={['menu1', 'menu2', 'menu3']} />
-      <DropdownButton id="a3" bsSize="small" title="small" menu={['menu1', 'menu2', 'menu3']} />
-      <DropdownButton id="a4" bsSize="xsmall" title="xsmall" menu={['menu1', 'menu2', 'menu3']} />
+      <DropdownButton id="a3" size="sm" title="sm" menu={['menu1', 'menu2', 'menu3']} />
+      <DropdownButton id="a4" size="xs" title="xs" menu={['menu1', 'menu2', 'menu3']} />
     </div>
   ))
   .add('style', () => (
     <div>
       <DropdownButton
         id="a1"
-        bsStyle="default"
+        variant="default"
         title="default"
         menu={['menu1', 'menu2', 'menu3']}
       />
       <DropdownButton
         id="a2"
-        bsStyle="primary"
+        variant="primary"
         title="primary"
         menu={['menu1', 'menu2', 'menu3']}
       />
       <DropdownButton
         id="a3"
-        bsStyle="success"
+        variant="success"
         title="success"
         menu={['menu1', 'menu2', 'menu3']}
       />
-      <DropdownButton id="a4" bsStyle="info" title="info" menu={['menu1', 'menu2', 'menu3']} />
+      <DropdownButton id="a4" variant="info" title="info" menu={['menu1', 'menu2', 'menu3']} />
       <DropdownButton
         id="a5"
-        bsStyle="warning"
+        variant="warning"
         title="warning"
         menu={['menu1', 'menu2', 'menu3']}
       />
-      <DropdownButton id="a6" bsStyle="danger" title="danger" menu={['menu1', 'menu2', 'menu3']} />
+      <DropdownButton id="a6" variant="danger" title="danger" menu={['menu1', 'menu2', 'menu3']} />
     </div>
   ))
-  .add('componentClass', () => (
+  .add('as', () => (
     <div>
       <DropdownButton
         id="a1"
         title="input group"
-        componentClass={InputGroup}
+        as={InputGroup}
         menu={['menu1', 'menu2', 'menu3']}
       />
       <DropdownButton id="a2" title="normal" menu={['menu1', 'menu2', 'menu3']} />
@@ -115,7 +115,7 @@ storiesOf('DropdownButton', module)
   ))
   .add('dropup', () => (
     <div style={{ paddingTop: '160px' }}>
-      <DropdownButton id="a1" title="dropup" dropup menu={['menu1', 'menu2', 'menu3']} />
+      <DropdownButton id="a1" title="dropup" drop="up" menu={['menu1', 'menu2', 'menu3']} />
       <DropdownButton id="a2" title="normal" menu={['menu1', 'menu2', 'menu3']} />
     </div>
   ))
@@ -139,12 +139,12 @@ storiesOf('DropdownButton', module)
       />
     </div>
   ))
-  .add('open', () => (
+  .add('show', () => (
     <div>
       <DropdownButton
         id="a1"
-        title="open"
-        open
+        title="show"
+        show
         onToggle={() => {}}
         menu={['menu1', 'menu2', 'menu3']}
       />
@@ -152,7 +152,7 @@ storiesOf('DropdownButton', module)
       <DropdownButton
         id="a3"
         title="close"
-        open={false}
+        show={false}
         onToggle={() => {}}
         menu={['menu1', 'menu2', 'menu3']}
       />
@@ -166,7 +166,7 @@ storiesOf('DropdownButton', module)
           <DropdownButton
             id="a1"
             title="onToggle"
-            open={visible}
+            show={visible}
             onToggle={() => updateVisible(!visible)}
             menu={['menu1', 'menu2', 'menu3']}
           />
@@ -175,10 +175,10 @@ storiesOf('DropdownButton', module)
     };
     return <ToggleDropdownButton />;
   })
-  .add('pullRight', () => (
+  .add('align', () => (
     <div>
       <DropdownButton id="a2" title="normal" menu={['menu1', 'menu2', 'menu3']} />
-      <DropdownButton id="a1" title="pullRight" pullRight menu={['menu1', 'menu2', 'menu3']} />
+      <DropdownButton id="a1" title="align" align="end" menu={['menu1', 'menu2', 'menu3']} />
     </div>
   ))
   .add('title', () => (

--- a/stories/InputGroup.stories.tsx
+++ b/stories/InputGroup.stories.tsx
@@ -43,7 +43,7 @@ storiesOf('Form | InputGroup', module)
             <FormControl type="number" />
             <DropdownButton
               id="unit-dropdown"
-              componentClass={InputGroup}
+              as={InputGroup}
               title={isHour ? '小时' : '分钟'}
               menu={menu}
             />


### PR DESCRIPTION
升级前：
![image](https://github.com/xsky-fe/wizard-ui/assets/70199559/71d524df-644a-4c13-bc9d-232690114962)
升级后：
![image](https://github.com/xsky-fe/wizard-ui/assets/70199559/01e5f5a5-d7a8-4437-a683-53525432770b)
![image](https://github.com/xsky-fe/wizard-ui/assets/70199559/cad130ad-b944-4d2f-9152-db28329c9cad)
![image](https://github.com/xsky-fe/wizard-ui/assets/70199559/20bce855-b467-459d-81bf-33f43590a950)

变更：
1. bsize  -> size
2. bsStyle -> variant
3. componentClass -> as
4. dropup -> drop，支持 string 去指定弹出方向
5. open  -> show
6. pullRight -> align，支持 string 去指定对齐方向