### PR TITLE
modify input group component

### DIFF
--- a/docs/src/components/Search/index.js
+++ b/docs/src/components/Search/index.js
@@ -20,9 +20,9 @@ const Search = props => {
   return (
     <div className="HeaderSearch">
       <InputGroup>
-        <InputGroup.Addon>
+        <InputGroup.Text>
           <Icon type="search"/>
-        </InputGroup.Addon>
+        </InputGroup.Text>
         <FormControl
           value={query}
           onChange={handleChange}

--- a/stories/InputGroup.stories.tsx
+++ b/stories/InputGroup.stories.tsx
@@ -6,10 +6,26 @@ storiesOf('InputGroup', module)
   .add('default', () => (
     <InputGroup>
       <FormControl type="text" disabled />
-      <InputGroup>
-        <Button>选择文件</Button>
-      </InputGroup>
+      <Button>选择文件</Button>
     </InputGroup>
+  ))
+  .add('hasAddonText', () => (
+    <div>
+      <p>
+        <div>后缀</div>
+        <InputGroup>
+          <FormControl type="text" />
+          <InputGroup.Text>.com</InputGroup.Text>
+        </InputGroup>
+      </p>
+      <p>
+        <div>前缀</div>
+        <InputGroup>
+          <InputGroup.Text>http://</InputGroup.Text>
+          <FormControl type="text" />
+        </InputGroup>
+      </p>
+    </div>
   ))
   .add('hasDropdownButton', () => {
     const Demo = () => {


### PR DESCRIPTION
v5 不支持 <InputGroup.Addon> 用法，改为以下用法
<img width="862" alt="image" src="https://github.com/xsky-fe/wizard-ui/assets/46660312/33064832-e6f8-4902-9b1d-ad8d9a168ef3">
<img width="1208" alt="image" src="https://github.com/xsky-fe/wizard-ui/assets/46660312/a6b01e58-b687-4866-a6da-4f6c7c0162bb">
