### PR TITLE
refactor: steps style

### DIFF
--- a/src/components/Steps/index.tsx
+++ b/src/components/Steps/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { Container } from 'react-bootstrap';
 import Badge from '../Badge';
 import { getBemClass } from '../../utils';
 import { StepsProps } from '../../interface';
@@ -10,7 +9,7 @@ import './style.scss';
 const Steps: React.FC<StepsProps> = props => {
   const { steps, currentStep, showIcon, iconSize, iconStatus } = props;
   return (
-    <Container className="Steps">
+    <div className="Steps">
       {steps.map((step, index) => {
         const stepLabel = typeof step === 'string' ? step : step.label;
         const stepCount = typeof step === 'string' ? false : step.count;
@@ -30,7 +29,7 @@ const Steps: React.FC<StepsProps> = props => {
           </div>
         );
       })}
-    </Container>
+    </div>
   );
 };
 

--- a/src/components/Steps/style.scss
+++ b/src/components/Steps/style.scss
@@ -1,5 +1,14 @@
+@import '../../style/variables.scss';
+
 .Steps {
+  color: $text-1;
   text-align: center;
+  background-color: $bg-2;
+  line-height: 20px;
+  font-size: $font-size-14;
+  padding: 8px 16px;
+  margin-bottom: 20px;
+  border-radius: $radius-middle;
 }
 .Steps__Step {
   display: inline-block;

--- a/stories/Steps.stories.tsx
+++ b/stories/Steps.stories.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Steps } from '../src';
+
+storiesOf('Steps', module).add('default', () => {
+  const stepTexts = ['选择资源', '设置恢复任务', '确认信息'];
+  return <Steps steps={stepTexts} currentStep={2} />;
+});


### PR DESCRIPTION
旧版 steps 最外层使用了 well 组件包裹，现已弃用该组件，将项目中步骤条相关样式搬过来。
![image](https://github.com/xsky-fe/wizard-ui/assets/46660312/e992a31a-3c38-4beb-822c-f5f3727ee1c8)
