### PR TITLE
fix: [XSOS-4954] change dropdown direction

### DIFF
--- a/src/components/Dropdown/style.scss
+++ b/src/components/Dropdown/style.scss
@@ -4,10 +4,6 @@
   -webkit-box-shadow: 0 6px 12px rgba($black, .18);
   box-shadow: 0 6px 12px rgba($black, .18);
 }
-.show.btn-default.dropdown-toggle {
-  color: $text-2;
-  background-color: $bg-2-hover;
-  border-color: $grey-7;
-  -webkit-box-shadow: inset 0 3px 5px rgba($black, .125);
-  box-shadow: inset 0 3px 5px rgba($black, .125);
+.show.dropdown-toggle::after {
+  transform: rotate(180deg);
 }


### PR DESCRIPTION
[【UI验收】全局资源项点击操作，下拉小三角icon方向没有变化](https://issue.xsky.com/browse/XSOS-4954?filter=-1)

<img width="417" alt="image" src="https://github.com/xsky-fe/wizard-ui/assets/70199559/ec4495eb-1f97-4a78-a14f-765df5b1140e">
