### PR TITLE
fix: [XEOS-9576] change switch disabled opacity

### DIFF
--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -44,6 +44,7 @@ const Switch: React.FC<SwitchProps> = props => {
       <ReactIOSSwitch
         className="react-ios-switch-Switch-switch"
         disabled={disabled}
+        style={{ opacity: disabled ? 0.3 : 1 }}
         {...input}
         {...rest}
         checked={checked}


### PR DESCRIPTION
[【组件升级】创建存储桶页面，开启压缩后，追加写的swich组件disable状态时预期透明度为0.3.](https://issue.xsky.com/browse/XEOS-9576)