### PR TITLE
feat: add false type in button tooltip

### DIFF
--- a/src/components/Button/index.test.tsx
+++ b/src/components/Button/index.test.tsx
@@ -3,10 +3,10 @@ import Button from './index';
 import { mount } from 'enzyme';
 
 describe('Button-Tooltip', () => {
-  it('Button is not disabled and show toolTip', () => {
+  it('Button is not disabled and show tooltip', () => {
     const button = mount(
       <Button
-        toolTip={{ placement: 'top', children: 'tooltip showed and able to click' }}
+        tooltip={{ placement: 'top', children: 'tooltip showed and able to click' }}
         onClick={() => (document.title = 'clicked')}
       >
         click
@@ -20,11 +20,11 @@ describe('Button-Tooltip', () => {
     button.simulate('click');
     expect(document.title === 'clicked');
   });
-  it('Button is disabled and show toolTip', () => {
+  it('Button is disabled and show tooltip', () => {
     const button = mount(
       <Button
         disabled
-        toolTip={{ placement: 'top', children: 'tooltip showed and not allowed to click' }}
+        tooltip={{ placement: 'top', children: 'tooltip showed and not allowed to click' }}
         onClick={() => (document.title = 'clicked')}
       >
         click

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -6,8 +6,8 @@ import classNames from 'classnames';
 import './style.scss';
 
 const Button: React.FC<ButtonProps> = (props: any) => {
-  const { tooltip, children, ...restProps } = props;
-  const { disabled, className = null, block, variant } = restProps;
+  const { tooltip, children, block, ...restProps } = props;
+  const { disabled, className = null, variant } = restProps;
   const tooltipClassName = disabled ? `Button_Tooltip-Div-Button ${className}` : '';
   const blockClassName = block ? 'btn-block' : '';
 
@@ -38,7 +38,7 @@ const Button: React.FC<ButtonProps> = (props: any) => {
 };
 
 Button.defaultProps = {
-  variant:'info',
+  variant: 'info',
   active: false,
   disabled: false,
   block: false

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -6,25 +6,25 @@ import classNames from 'classnames';
 import './style.scss';
 
 const Button: React.FC<ButtonProps> = (props: any) => {
-  const { toolTip, children, ...restProps } = props;
+  const { tooltip, children, ...restProps } = props;
   const { disabled, className = null, block, variant } = restProps;
-  const toolTipClassName = disabled ? `Button_Tooltip-Div-Button ${className}` : '';
+  const tooltipClassName = disabled ? `Button_Tooltip-Div-Button ${className}` : '';
   const blockClassName = block ? 'btn-block' : '';
 
-  return toolTip ? (
+  return tooltip ? (
     <Tooltip
       label={
         <div className="Button_Tooltip-Div">
           <BSButton
             variant={variant ? variant : 'default'}
             {...restProps}
-            className={classNames(toolTipClassName, blockClassName, className)}
+            className={classNames(tooltipClassName, blockClassName, className)}
           >
             {children}
           </BSButton>
         </div>
       }
-      {...toolTip}
+      {...tooltip}
     />
   ) : (
     <BSButton

--- a/src/components/DropdownButton/index.tsx
+++ b/src/components/DropdownButton/index.tsx
@@ -75,13 +75,13 @@ function renderMenu(
     // 如果有传入 onSelect 回调函数，会继续执行传入的回调函数
     if (onSelect) onSelect(eventKey);
   };
-  const menuProps = omit(item, ['toolTip', 'divider']);
+  const menuProps = omit(item, ['tooltip', 'divider']);
 
   return (
     <Dropdown.Item {...menuProps} onSelect={handleItemSelect}>
-      {item.toolTip ? (
-        <Tooltip {...item.toolTip} label={item?.toolTip?.label || item.title} placement={item?.toolTip?.placement || 'right'}>
-          {item.toolTip.children}
+      {item.tooltip ? (
+        <Tooltip {...item.tooltip} label={item?.tooltip?.label || item.title} placement={item?.tooltip?.placement || 'right'}>
+          {item.tooltip.children}
         </Tooltip>
       ) : (
         item.title

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -324,7 +324,7 @@ export type DropdownButtonMenuItem =
       onClick?: any;
       onSelect?: Function;
       disabled?: boolean;
-      toolTip?: TooltipProps;
+      tooltip?: TooltipProps;
       divider?: boolean;
     }
   | string;
@@ -656,7 +656,7 @@ export interface NotificationListStates {
 
 export interface ButtonProps extends BaseButtonProps {
   /**按钮文字提示 */
-  toolTip?: TooltipProps | false;
+  tooltip?: TooltipProps | false;
   /**按钮占据整行 */
   block?: boolean;
   /**按钮的状态 */

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -656,7 +656,7 @@ export interface NotificationListStates {
 
 export interface ButtonProps extends BaseButtonProps {
   /**按钮文字提示 */
-  toolTip?: TooltipProps;
+  toolTip?: TooltipProps | false;
   /**按钮占据整行 */
   block?: boolean;
   /**按钮的状态 */

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -102,10 +102,17 @@ export const Tooltip: Story = {
         onClick={() => {
           alert('clicked');
         }}
+        style={{ marginRight: '10px' }}
       >
         button
       </Button>
-    </div>
+      <Button
+        toolTip={false}
+        disabled={true}
+      >
+        disabled but no toolTip
+      </Button>
+    </div >
   ),
 };
 

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -87,7 +87,7 @@ export const Tooltip: Story = {
     <div style={{ margin: '10px' }}>
       <Button
         variant="info"
-        toolTip={DisabledTooltip}
+        tooltip={DisabledTooltip}
         disabled={true}
         onClick={() => {
           alert('clicked');
@@ -97,7 +97,7 @@ export const Tooltip: Story = {
         button
       </Button>
       <Button
-        toolTip={NormalTooltip}
+        tooltip={NormalTooltip}
         disabled={false}
         onClick={() => {
           alert('clicked');
@@ -107,10 +107,10 @@ export const Tooltip: Story = {
         button
       </Button>
       <Button
-        toolTip={false}
+        tooltip={false}
         disabled={true}
       >
-        disabled but no toolTip
+        disabled but no tooltip
       </Button>
     </div >
   ),

--- a/stories/DropdownButton.stories.tsx
+++ b/stories/DropdownButton.stories.tsx
@@ -203,19 +203,19 @@ export const Menu: Story = {
             key: 'menu1',
             title: 'menu1',
             disabled: true,
-            toolTip: { label: 'menu1', children: 'Not allow to operate' },
+            tooltip: { label: 'menu1', children: 'Not allow to operate' },
           },
           {
             key: 'menu2',
             title: 'menu2',
             disabled: true,
-            toolTip: { label: 'menu1', children: 'Not allow to operate', placement: 'top' },
+            tooltip: { label: 'menu1', children: 'Not allow to operate', placement: 'top' },
           },
           {
             key: 'menu3',
             title: 'menu3',
             disabled: true,
-            toolTip: { children: 'Not allow to operate' },
+            tooltip: { children: 'Not allow to operate' },
           },
         ]}
       />


### PR DESCRIPTION
button 传入的 tooltip 支持 false ,用来支持下面的写法
```js
<Button
  tooltip={ boolean && {
    children: 'xx'
  }}
>
xx
</Button>
```
Button & DropdownButton 的 tooltip 拼写错误修复
realated: https://github.xsky.com/front-end/xsky-wizard/pull/6264
https://xskydata.feishu.cn/wiki/CrSowghZoiAIuBkgezjcqf8lnme