### PR TITLE
fix: button tooltip bug

### DIFF
--- a/src/components/Button/style.scss
+++ b/src/components/Button/style.scss
@@ -8,7 +8,7 @@
   display: inline-block;
   cursor: not-allowed;
 
-  &-Button {
+  .btn[disabled] {
     pointer-events: none;
   }
 }


### PR DESCRIPTION
问题：
wizard 全局问题，disabled button 的 tooltip 一直悬浮，不会消失
![image](https://github.com/xsky-fe/wizard-ui/assets/55693803/591adb8f-e7b7-41ba-bdd3-fa59fe8e448f)
storybook 上也有：
![image](https://github.com/xsky-fe/wizard-ui/assets/55693803/07fc0762-6bc5-4e00-9daf-dc6a1226acb3)

被 button disabled 的属性影响了
![image](https://github.com/xsky-fe/wizard-ui/assets/55693803/6e0d5143-e160-410b-b715-d98f0c04643c)
