### PR TITLE
fix: [XEOS-9628] fix tooltip arrow not center bug

### DIFF
--- a/src/components/Tooltip/style.scss
+++ b/src/components/Tooltip/style.scss
@@ -8,6 +8,13 @@
   }
 }
 .tooltip {
+  &.bs-tooltip-top,
+  &.bs-tooltip-bottom {
+    .tooltip-arrow {
+      left: 50%!important;
+      transform: translate(-50%, 0)!important;
+    }
+  }
   .tooltip-inner {
     box-shadow: $shadow-tooltip;
   }


### PR DESCRIPTION
- 修复tooltips内容区内容变动之后，箭头没有居中的问题