### PR TITLE
fix: [XSOS-6016] fix VirtualList resize height error

### DIFF
--- a/src/components/VirtualList/index.tsx
+++ b/src/components/VirtualList/index.tsx
@@ -316,7 +316,7 @@ export default class VirtualList<T> extends React.Component<VirtualListProps<T>,
   };
 
   tryToFetchData = () => {
-    const { data, query, onQueryChange, isFetching,error } = this.props;
+    const { data, query, onQueryChange, isFetching, error } = this.props;
     const { endIndex } = this.state;
     if (error) return;
     if (isFetching) return;
@@ -346,11 +346,7 @@ export default class VirtualList<T> extends React.Component<VirtualListProps<T>,
     } = this.props;
     const noData = data.length === 0;
     return (
-      <div
-        className="VirtualList__holder"
-        ref={this.holder}
-        style={{ height: noData ? '100vh' : height }}
-      >
+      <div className="VirtualList__holder" ref={this.holder} style={{ height }}>
         <div
           className="VirtualList__wrapper"
           style={{ height: this.wrapperHeight }}

--- a/src/components/VirtualList/index.tsx
+++ b/src/components/VirtualList/index.tsx
@@ -346,7 +346,11 @@ export default class VirtualList<T> extends React.Component<VirtualListProps<T>,
     } = this.props;
     const noData = data.length === 0;
     return (
-      <div className="VirtualList__holder" ref={this.holder} style={{ height }}>
+      <div
+        className="VirtualList__holder"
+        ref={this.holder}
+        style={{ height: noData ? '100vh' : height }}
+      >
         <div
           className="VirtualList__wrapper"
           style={{ height: this.wrapperHeight }}

--- a/src/components/VirtualList/style.scss
+++ b/src/components/VirtualList/style.scss
@@ -8,3 +8,6 @@
 .VirtualList__loader {
   padding-left: 10px
 }
+.VirtualList__holder {
+  max-height: 100vh;
+}


### PR DESCRIPTION
- [缩放屏幕恢复后，资源详情页下拉空包页面居多无法恢复](https://issue.xsky.com/browse/XSOS-6016?filter=-1&jql=assignee%20in%20(currentUser())%20order%20by%20updated%20DESC)