### PR TITLE
fix: [XEOS-9999] fix tag z-index error

### DIFF
--- a/src/components/Tabs/style.scss
+++ b/src/components/Tabs/style.scss
@@ -97,7 +97,6 @@
 
 .Tabs:not(.Tabs--secondary) >#Tabs >.nav-tabs > li {
   position: relative;
-  z-index: 1;
   &:has(a:active),
   &:has(a.active) {
     border-top: 2px solid $primary-normal;


### PR DESCRIPTION
- [【管理面】分辨率1280px时，站点详情更多下拉和列表tab层级问题。](https://issue.xsky.com/browse/XEOS-9999?filter=-1&jql=project%20in%20(XSOS%2C%20XEOS)%20AND%20assignee%20in%20(currentUser())%20order%20by%20updated%20DESC)
修复前：
![image](https://github.com/xsky-fe/wizard-ui/assets/5915045/5aadf71b-8e2a-4e0c-8e10-80896caf047b)
修复后：
![image](https://github.com/xsky-fe/wizard-ui/assets/5915045/0405dd89-0cf1-4934-80d3-ddcdffe456a7)
