### PR TITLE
fix: [XSOS-6398] fix tooltips center error

### DIFF
--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -16,6 +16,7 @@ const Tooltip: React.FC<TooltipProps> = props => {
     contrast,
     className,
     style,
+    arrowAlign,
     children,
     placement: defaultPlacement,
     ...extra
@@ -75,7 +76,7 @@ const Tooltip: React.FC<TooltipProps> = props => {
         <BaseTooltip
           id="tooltip"
           style={Object.assign({}, { maxWidth: 280 }, style)}
-          className={`${cn({ contrast })} ${className}`}
+          className={`${cn({ contrast, 'tooltip-center': arrowAlign === 'center' })} ${className}`}
           onMouseEnter={handleShow}
           onMouseLeave={handleHide}
         >
@@ -120,12 +121,17 @@ Tooltip.propTypes = {
    * 样式
    */
   style: PropTypes.object,
+  /**
+   * 箭头对齐方式
+   */
+  arrowAlign: PropTypes.oneOf(['center', 'auto']),
 };
 
 Tooltip.defaultProps = {
   icon: 'tip-line',
   iconAlign: 'text-bottom',
   contrast: false,
+  arrowAlign: 'center',
 };
 
 export default Tooltip;

--- a/src/components/Tooltip/style.scss
+++ b/src/components/Tooltip/style.scss
@@ -8,11 +8,13 @@
   }
 }
 .tooltip {
-  &.bs-tooltip-top,
-  &.bs-tooltip-bottom {
-    .tooltip-arrow {
-      left: 50%!important;
-      transform: translate(-50%, 0)!important;
+  &.tooltip-center {
+    &.bs-tooltip-top,
+    &.bs-tooltip-bottom {
+      .tooltip-arrow {
+        left: 50%!important;
+        transform: translate(-50%, 0)!important;
+      }
     }
   }
   .tooltip-inner {

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -77,6 +77,8 @@ export interface IconProps {
 }
 
 export interface TooltipProps {
+  /**箭头对齐方式*/
+  arrowAlign?: 'center' | 'auto';
   /**给图标传入的其他 class； */
   iconClass?: string;
   /**icon的type,用于图标提示 */


### PR DESCRIPTION
- [【组件】全局固定tooltips三角居中后，平台概览靠右侧小i的tooltips偏移显示问题。](https://issue.xsky.com/browse/XSOS-6398?filter=-1&jql=project%20in%20(XSOS%2C%20XEOS)%20AND%20assignee%20in%20(currentUser())%20order%20by%20updated%20DESC)